### PR TITLE
fix(build): adapted the perl command to specify the backup file exten…

### DIFF
--- a/build-functions.sh
+++ b/build-functions.sh
@@ -348,7 +348,7 @@ updateVersionReferences() {
     cd ${NPM_DIR}
     
     local PATTERN="0\.0\.0\-PLACEHOLDER\-VERSION"
-    perl -p -i -e "s/$PATTERN/$1/g" ./package.json
+    perl -p -i.bak -e "s/$PATTERN/$1/g" ./package.json
   )
 }
 
@@ -367,7 +367,7 @@ updatePackageNameReferences() {
     cd ${NPM_DIR}
     
     local PATTERN="PLACEHOLDER\-PACKAGE\-NAME"
-    perl -p -i -e "s/$PATTERN/$1/g" ./package.json
+    perl -p -i.bak -e "s/$PATTERN/$1/g" ./package.json
   )
 }
 
@@ -440,7 +440,7 @@ adaptNpmPackageDependencies() {
   # Packages will have dependencies between them. They will so have "devDependencies" and "peerDependencies" with different values.
   # We should only replace the value of the devDependency for make it work.
 
-  perl -p -i -e "s/$PATTERN/$REPLACEMENT/" $PACKAGE_JSON_FILE
+  perl -p -i.bak -e "s/$PATTERN/$REPLACEMENT/" $PACKAGE_JSON_FILE
 }
 
 #######################################
@@ -490,7 +490,7 @@ logTrace "Executing function: ${FUNCNAME[0]}" 1
   # Packages will have dependencies between them. They will so have "devDependencies" and "peerDependencies" with different values.
   # We should only replace the value of the devDependency for make it work.
   
-  perl -p -i -0 -e "s/$PATTERN/$REPLACEMENT/m" $PACKAGE_JSON_FILE
+  perl -p -i.bak -0 -e "s/$PATTERN/$REPLACEMENT/m" $PACKAGE_JSON_FILE
 }
 
 #######################################


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/NationalBankBelgium/stark/blob/master/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
Adapted the perl calls to always specify the backup file extension. This is necessary for some versions of perl

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
No extension specified and build failures with some perl installs (e.g., strawberry)

Issue Number: N/A


## What is the new behavior?
Extension specified.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information